### PR TITLE
Fixing #58 - Check if there are any test variants when plugin is applied

### DIFF
--- a/okreplay-gradle-plugin/src/main/kotlin/okreplay/OkReplayPlugin.kt
+++ b/okreplay-gradle-plugin/src/main/kotlin/okreplay/OkReplayPlugin.kt
@@ -92,7 +92,11 @@ class OkReplayPlugin
   private fun testApplicationId(): String {
     val androidConfig = androidConfig()
     if (androidConfig is AppExtension || androidConfig is LibraryExtension) {
-      return (androidConfig as TestedExtension).testVariants.first().applicationId
+      if (!(androidConfig as TestedExtension).testVariants.isEmpty()) {
+        return (androidConfig as TestedExtension).testVariants.first().applicationId
+      } else {
+        return ""
+      }
     } else {
       throw IllegalStateException("Invalid project type")
     }


### PR DESCRIPTION
This PR fixes the build error specified in https://github.com/airbnb/okreplay/issues/58.

When the application variant is not a test variant, the list `(androidConfig as TestedExtension).testVariants` is empty, and should not be used to get the test application ID.

This PR checks to see if the list is not empty before calling `(androidConfig as TestedExtension).testVariants.first()` in the ok replay plugin.