### PR TITLE
Adding support for a quiet mode

### DIFF
--- a/okreplay-core/src/main/java/okreplay/OkReplayInterceptor.java
+++ b/okreplay-core/src/main/java/okreplay/OkReplayInterceptor.java
@@ -57,7 +57,6 @@ public class OkReplayInterceptor implements Interceptor {
           // talking to the server for non-mutable tapes.
           if (!tape.isWritable()) {
             throwTapeNotWritable(request.method() + " " + request.url().toString());
-            return;
           }
 
           // Continue the request and attempt to write the response to the tape.

--- a/okreplay-core/src/main/java/okreplay/OkReplayInterceptor.java
+++ b/okreplay-core/src/main/java/okreplay/OkReplayInterceptor.java
@@ -43,6 +43,17 @@ public class OkReplayInterceptor implements Interceptor {
         } else {
           LOG.warning(String.format("no matching request found on tape '%s' for request %s %s",
               tape.getName(), request.method(), request.url().toString()));
+          if (tape.getMode() == TapeMode.READ_ONLY_QUIET) {
+            return new okhttp3.Response.Builder()
+                .protocol(Protocol.HTTP_1_1)
+                .code(404)
+                .message("")
+                .body(ResponseBody.create(MediaType.parse("text/plain"), "No matching response"))
+                .request(chain.request())
+                .build();
+          }
+
+          // Continue the request and attempt to write the response to the tape.
           okhttp3.Response okhttpResponse = chain.proceed(request);
           okhttpResponse = setOkReplayHeader(okhttpResponse, "REC");
           okhttpResponse = setViaHeader(okhttpResponse);

--- a/okreplay-core/src/main/java/okreplay/TapeMode.java
+++ b/okreplay-core/src/main/java/okreplay/TapeMode.java
@@ -2,8 +2,8 @@ package okreplay;
 
 public enum TapeMode {
   UNDEFINED(false, false, false), READ_WRITE(true, true, false), READ_ONLY(true, false, false),
-  READ_SEQUENTIAL(true, false, true), WRITE_ONLY(false, true, false), WRITE_SEQUENTIAL(false,
-      true, true);
+  READ_ONLY_QUIET(true, false, false), READ_SEQUENTIAL(true, false, true), WRITE_ONLY(false,
+      true, false), WRITE_SEQUENTIAL(false, true, true);
 
   private final boolean readable;
   private final boolean writable;


### PR DESCRIPTION
This PR adds support for "quiet" mode. Currently, the READ_ONLY mode treats not finding a request as a hard error, throwing a NonWritableTapeException. This is certainly reasonable and desired behavior for many types of tests.

But for some tests, this behavior leads to excessive brittleness. If a code path under test is commonly used, this behavior means that any additional network calls require re-recording a significant number of tests even if the behavior is not expected to change.

In this PR, READ_ONLY_QUIET treats requests that are not present in the tape as simple 404 errors - similar to how the lack of a tape itself is presented as a 403. This allows tests to continue to pass without needing to be re-recorded.