### PR TITLE
Memoize RecordedInteraction conversion

### DIFF
--- a/okreplay-core/src/main/java/okreplay/YamlRecordedInteraction.java
+++ b/okreplay-core/src/main/java/okreplay/YamlRecordedInteraction.java
@@ -6,6 +6,7 @@ public class YamlRecordedInteraction {
   private final Date recorded;
   private final YamlRecordedRequest request;
   private final YamlRecordedResponse response;
+  private transient RecordedInteraction immutableInteraction;
 
   YamlRecordedInteraction(Date recorded, YamlRecordedRequest request,
       YamlRecordedResponse response) {
@@ -20,6 +21,13 @@ public class YamlRecordedInteraction {
   }
 
   RecordedInteraction toImmutable() {
-    return new RecordedInteraction(recorded, request.toImmutable(), response.toImmutable());
+    if (immutableInteraction == null) {
+      immutableInteraction = createImmutable();
+    }
+    return immutableInteraction;
+  }
+
+  private RecordedInteraction createImmutable() {
+      return new RecordedInteraction(recorded, request.toImmutable(), response.toImmutable());
   }
 }


### PR DESCRIPTION
`toImmutable()` is called very frequently from `MemoryTape`, especially from `findMatch` which loops through each interaction. `findMatch` is a synchronized method too so when multiple requests are in flight only one can enter `findMatch` at a time.

As this method returns only value per `YamlRecordedInteraction` instance, memoizing can speed things up a lot. In cases where our app make multiple requests simultaneously, it's causing some responses to return in 10ms where they were taking over 200ms before. 