### PR TITLE
Compatibility fixes for AGP v3.5.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,6 +1,6 @@
 ext.versions = [
     okreplayVersion : VERSION_NAME,
-    kotlinVersion   : '1.3.30',
+    kotlinVersion   : '1.3.40',
     okhttpVersion   : '3.11.0',
     appCompatVersion: '1.0.2'
 ]
@@ -10,7 +10,7 @@ ext {
   isCi = "true" == System.getenv('CI')
 
   dep = [
-      androidPlugin       : 'com.android.tools.build:gradle:3.4.1',
+      androidPlugin       : 'com.android.tools.build:gradle:3.5.0',
       groovyPlugin        : 'org.codehaus.groovy:groovy-android-gradle-plugin:1.1.0',
       nexusPlugin         : 'com.bmuschko:gradle-nexus-plugin:2.3.1',
       appcompat           : "androidx.appcompat:appcompat:$versions.appCompatVersion",
@@ -27,7 +27,7 @@ ext {
       mockWebServer       : "com.squareup.okhttp3:mockwebserver:$versions.okhttpVersion",
       snakeYaml           : "org.yaml:snakeyaml:1.16",
       kotlinStdLib        : "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlinVersion",
-      okreplayPlugin      : "com.airbnb.okreplay:gradle-plugin:latest.release",
+      okreplayPlugin      : "com.airbnb.okreplay:gradle-plugin:$VERSION_NAME",
       kotlinPlugin        : "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlinVersion",
       truth               : 'com.google.truth:truth:0.40',
       robolectric         : "org.robolectric:robolectric:3.3.2",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,7 +1,7 @@
 ext.versions = [
     okreplayVersion : VERSION_NAME,
     kotlinVersion   : '1.3.40',
-    okhttpVersion   : '3.11.0',
+    okhttpVersion   : '3.12.2',
     appCompatVersion: '1.0.2'
 ]
 ext {
@@ -23,6 +23,7 @@ ext {
       cglib               : "cglib:cglib-nodep:2.2.2",
       jsr305              : "com.google.code.findbugs:jsr305:3.0.2",
       mockito             : 'org.mockito:mockito-core:2.7.13',
+      okio                : 'com.squareup.okio:okio:1.17.2',
       okhttp              : "com.squareup.okhttp3:okhttp:$versions.okhttpVersion",
       mockWebServer       : "com.squareup.okhttp3:mockwebserver:$versions.okhttpVersion",
       snakeYaml           : "org.yaml:snakeyaml:1.16",
@@ -36,6 +37,7 @@ ext {
         exclude module: "junit"
       }),
       espresso          : 'androidx.test.espresso:espresso-core:3.1.0',
+      androidXTestRunner: 'androidx.test:runner:1.2.0',
       androidXTestRules : 'androidx.test:rules:1.1.1'
   ]
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,6 +1,6 @@
 ext.versions = [
     okreplayVersion : VERSION_NAME,
-    kotlinVersion   : '1.3.40',
+    kotlinVersion   : '1.3.50',
     okhttpVersion   : '3.12.2',
     appCompatVersion: '1.0.2'
 ]

--- a/okreplay-core/src/main/java/okreplay/MemoryTape.java
+++ b/okreplay-core/src/main/java/okreplay/MemoryTape.java
@@ -73,7 +73,7 @@ abstract class MemoryTape implements Tape {
       try {
         // TODO: it's a complete waste of time using an AtomicInteger when this method is called
         // before play in a non-transactional way
-        Integer index = orderedIndex.get();
+        int index = orderedIndex.get();
         RecordedInteraction interaction = interactions.get(index).toImmutable();
         Request nextRequest = interaction == null ? null : interaction.request();
         return nextRequest != null && matchRule.isMatch(request, nextRequest);
@@ -91,7 +91,7 @@ abstract class MemoryTape implements Tape {
     }
 
     if (mode.isSequential()) {
-      Integer nextIndex = orderedIndex.getAndIncrement();
+      int nextIndex = orderedIndex.getAndIncrement();
       RecordedInteraction nextInteraction = interactions.get(nextIndex).toImmutable();
       if (nextInteraction == null) {
         throw new IllegalStateException(String.format("No recording found at position %s",

--- a/okreplay-core/src/main/java/okreplay/OkReplayConfig.java
+++ b/okreplay-core/src/main/java/okreplay/OkReplayConfig.java
@@ -151,7 +151,7 @@ public class OkReplayConfig {
       if (properties.containsKey("okreplay.defaultMatchRules")) {
         String property = properties.getProperty("okreplay.defaultMatchRules");
         List<MatchRule> rules = new ArrayList<>();
-        for (String s : Arrays.asList(property.split(","))) {
+        for (String s : property.split(",")) {
           rules.add(MatchRules.valueOf(s));
         }
         defaultMatchRule(ComposedMatchRule.of(rules));

--- a/okreplay-gradle-plugin/src/main/kotlin/okreplay/OkReplayPlugin.kt
+++ b/okreplay-gradle-plugin/src/main/kotlin/okreplay/OkReplayPlugin.kt
@@ -62,9 +62,9 @@ class OkReplayPlugin
             project.tasks.create("pull${targetName}OkReplayTapes", PullTapesTask::class.java)
         val clearTapesTask: TapeTask =
             project.tasks.create("clear${targetName}OkReplayTapes", ClearTapesTask::class.java)
-        val globalScope = it.globalScope()
-        val adbPath = globalScope.androidBuilder.sdkInfo.adb
-        val adbTimeoutMs = globalScope.extension.adbOptions.timeOutInMs
+        val extension = project.extensions.getByType(BaseExtension::class.java)
+        val adbPath = extension.adbExecutable
+        val adbTimeoutMs = extension.adbOptions.timeOutInMs
         val testApplicationId = project.testApplicationId()
         val deviceBridge = DeviceBridgeProvider.get(adbPath, adbTimeoutMs, project)
         listOf(pullTapesTask, clearTapesTask).forEach {

--- a/okreplay-junit/src/main/kotlin/okreplay/CharMatcher.kt
+++ b/okreplay-junit/src/main/kotlin/okreplay/CharMatcher.kt
@@ -85,14 +85,6 @@ internal abstract class CharMatcher : Predicate<Char> {
     return matches(character!!)
   }
 
-  /**
-   * Returns a string representation of this `CharMatcher`, such as
-   * `CharMatcher.or(WHITESPACE, JAVA_DIGIT)`.
-   */
-  override fun toString(): String {
-    return super.toString()
-  }
-
   // Fast matchers
 
   /** A matcher for which precomputation will not yield any significant benefit.  */

--- a/okreplay-sample/build.gradle
+++ b/okreplay-sample/build.gradle
@@ -26,6 +26,10 @@ android {
   lintOptions {
     disable 'InvalidPackage'
   }
+
+  useLibrary 'android.test.runner'
+  useLibrary 'android.test.base'
+  useLibrary 'android.test.mock'
 }
 
 dependencies {
@@ -49,11 +53,13 @@ dependencies {
   kapt 'com.ryanharter.auto.value:auto-value-moshi:0.4.3'
   compileOnly 'com.ryanharter.auto.value:auto-value-moshi-annotations:0.4.3'
   testImplementation dep.junit
+  annotationProcessor 'com.google.auto.value:auto-value:1.5.2'
   kapt 'com.google.auto.value:auto-value:1.5.2'
   androidTestAnnotationProcessor 'com.google.auto.value:auto-value:1.5.2'
+  androidTestImplementation 'androidx.test.ext:junit:1.1.1'
   androidTestImplementation project(':okreplay-espresso')
   androidTestImplementation dep.androidXAnnotations
-  androidTestImplementation 'androidx.test:runner:1.1.1'
+  androidTestImplementation 'androidx.test:runner:1.2.0'
   androidTestImplementation dep.androidXTestRules
   androidTestImplementation 'com.squareup.okio:okio:1.14.0'
   androidTestImplementation dep.okhttp

--- a/okreplay-sample/build.gradle
+++ b/okreplay-sample/build.gradle
@@ -49,7 +49,7 @@ dependencies {
   kapt 'com.ryanharter.auto.value:auto-value-moshi:0.4.3'
   compileOnly 'com.ryanharter.auto.value:auto-value-moshi-annotations:0.4.3'
   testImplementation dep.junit
-  annotationProcessor 'com.google.auto.value:auto-value:1.5.2'
+  kapt 'com.google.auto.value:auto-value:1.5.2'
   androidTestAnnotationProcessor 'com.google.auto.value:auto-value:1.5.2'
   androidTestImplementation project(':okreplay-espresso')
   androidTestImplementation dep.androidXAnnotations

--- a/okreplay-sample/build.gradle
+++ b/okreplay-sample/build.gradle
@@ -47,7 +47,7 @@ dependencies {
   implementation 'com.squareup.retrofit2:converter-moshi:2.3.0'
   compileOnly 'com.google.auto.value:auto-value:1.5.2'
   implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
-  implementation 'com.squareup.okio:okio:1.14.0'
+  implementation dep.okio
   implementation dep.okhttp
   implementation dep.jsr305
   kapt 'com.ryanharter.auto.value:auto-value-moshi:0.4.3'
@@ -59,9 +59,9 @@ dependencies {
   androidTestImplementation 'androidx.test.ext:junit:1.1.1'
   androidTestImplementation project(':okreplay-espresso')
   androidTestImplementation dep.androidXAnnotations
-  androidTestImplementation 'androidx.test:runner:1.2.0'
+  androidTestImplementation dep.androidXTestRunner
   androidTestImplementation dep.androidXTestRules
-  androidTestImplementation 'com.squareup.okio:okio:1.14.0'
+  androidTestImplementation dep.okio
   androidTestImplementation dep.okhttp
   androidTestImplementation 'com.jakewharton.espresso:okhttp3-idling-resource:1.0.0'
 }

--- a/okreplay-sample/src/androidTest/java/okreplay/sample/ExampleInstrumentedBarTest.java
+++ b/okreplay-sample/src/androidTest/java/okreplay/sample/ExampleInstrumentedBarTest.java
@@ -3,7 +3,7 @@ package okreplay.sample;
 import androidx.test.espresso.IdlingRegistry;
 import androidx.test.espresso.IdlingResource;
 import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.jakewharton.espresso.OkHttp3IdlingResource;
 

--- a/okreplay-sample/src/androidTest/java/okreplay/sample/ExampleInstrumentedBarTest.java
+++ b/okreplay-sample/src/androidTest/java/okreplay/sample/ExampleInstrumentedBarTest.java
@@ -1,9 +1,10 @@
 package okreplay.sample;
 
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.IdlingRegistry;
 import androidx.test.espresso.IdlingResource;
-import androidx.test.rule.ActivityTestRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.ActivityTestRule;
 
 import com.jakewharton.espresso.OkHttp3IdlingResource;
 
@@ -21,7 +22,6 @@ import okreplay.OkReplayConfig;
 import okreplay.OkReplayRuleChain;
 import okreplay.TapeMode;
 
-import static androidx.test.InstrumentationRegistry.getContext;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
@@ -35,7 +35,7 @@ public class ExampleInstrumentedBarTest {
   private final ActivityTestRule<MainActivity> activityTestRule =
       new ActivityTestRule<>(MainActivity.class);
   private final OkReplayConfig configuration = new OkReplayConfig.Builder()
-      .tapeRoot(new AndroidTapeRoot(getContext(), getClass()))
+      .tapeRoot(new AndroidTapeRoot(ApplicationProvider.getApplicationContext(), getClass()))
       .defaultMode(TapeMode.READ_WRITE)
       .sslEnabled(true)
       .interceptor(graph.getOkReplayInterceptor())

--- a/okreplay-sample/src/androidTest/java/okreplay/sample/ExampleInstrumentedFooTest.java
+++ b/okreplay-sample/src/androidTest/java/okreplay/sample/ExampleInstrumentedFooTest.java
@@ -1,9 +1,10 @@
 package okreplay.sample;
 
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.IdlingRegistry;
 import androidx.test.espresso.IdlingResource;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
 
 import com.jakewharton.espresso.OkHttp3IdlingResource;
 
@@ -22,8 +23,6 @@ import okreplay.OkReplayConfig;
 import okreplay.OkReplayRuleChain;
 import okreplay.TapeMode;
 
-import static androidx.test.InstrumentationRegistry.getContext;
-import static androidx.test.InstrumentationRegistry.getTargetContext;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
@@ -37,8 +36,10 @@ public class ExampleInstrumentedFooTest {
   private final DependencyGraph graph = DependencyGraph.Companion.instance();
   private final ActivityTestRule<MainActivity> activityTestRule =
       new ActivityTestRule<>(MainActivity.class);
+  private final AssetManager assetManager =
+      new AssetManager(ApplicationProvider.getApplicationContext());
   private final OkReplayConfig configuration = new OkReplayConfig.Builder()
-      .tapeRoot(new AndroidTapeRoot(new AssetManager(getContext()), getClass().getSimpleName()))
+      .tapeRoot(new AndroidTapeRoot(assetManager, getClass().getSimpleName()))
       .defaultMode(TapeMode.READ_WRITE)
       .sslEnabled(true)
       .interceptor(graph.getOkReplayInterceptor())
@@ -60,7 +61,7 @@ public class ExampleInstrumentedFooTest {
   @Test
   @OkReplay
   public void foo() {
-    assertEquals("okreplay.sample", getTargetContext().getPackageName());
+    assertEquals("okreplay.sample", ApplicationProvider.getApplicationContext().getPackageName());
     onView(withId(R.id.navigation_repositories)).perform(click());
     onView(withId(R.id.message)).check(matches(withText(containsString("6502Android"))));
   }


### PR DESCRIPTION
Fixes #89 

I've also just uploaded a new version of `1.5.0-SNAPSHOT` with this code which seems to work fine with Android Gradle Plugin v3.5.0.

We can probably cut a new stable release for v1.5.0 if Airbnb folks are okay with that!

This PR also bumps some outdated dependencies and fixes deprecation warnings