### PR TITLE
Call `terminate()` on DeviceProvider

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,8 +15,8 @@ ext {
       // Need to use snapshot version and explicitly include javadoc/sources tasks until
       // https://github.com/vanniktech/gradle-maven-publish-plugin/issues/54 is fixed.
       gradleMavenPublishPlugin : 'com.vanniktech:gradle-maven-publish-plugin:0.9.0-SNAPSHOT',
-      androidPlugin            : 'com.android.tools.build:gradle:3.5.0',
-      groovyPlugin             : 'org.codehaus.groovy:groovy-android-gradle-plugin:1.1.0',
+      androidPlugin            : 'com.android.tools.build:gradle:3.6.0',
+      groovyPlugin             : 'org.codehaus.groovy:groovy-android-gradle-plugin:2.0.1',
       nexusPlugin              : 'com.bmuschko:gradle-nexus-plugin:2.3.1',
       appcompat                : "androidx.appcompat:appcompat:$versions.appCompatVersion",
       androidXAnnotations      : "androidx.annotation:annotation:1.0.1",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/okreplay-gradle-plugin/src/main/kotlin/okreplay/ClearTapesTask.kt
+++ b/okreplay-gradle-plugin/src/main/kotlin/okreplay/ClearTapesTask.kt
@@ -14,12 +14,14 @@ abstract class ClearTapesTask : DefaultTask(), TapeTask {
   @TaskAction
   internal fun clearTapes() {
     val deviceBridge = DeviceBridgeProvider.get(adbPath.get(), adbTimeout.get(), logger)
-    deviceBridge.devices().forEach { device ->
-      val externalStorage = device.externalStorageDir()
-      try {
-        device.deleteDirectory("$externalStorage/$REMOTE_TAPES_DIR/${packageName.get()}/")
-      } catch (e: RuntimeException) {
-        logger.error("ADB Command failed: ${e.message}")
+    deviceBridge.use {
+      devices().forEach { device ->
+        val externalStorage = device.externalStorageDir()
+        try {
+          device.deleteDirectory("$externalStorage/$REMOTE_TAPES_DIR/${packageName.get()}/")
+        } catch (e: RuntimeException) {
+          logger.error("ADB Command failed: ${e.message}")
+        }
       }
     }
   }

--- a/okreplay-gradle-plugin/src/main/kotlin/okreplay/DeviceBridgeProvider.kt
+++ b/okreplay-gradle-plugin/src/main/kotlin/okreplay/DeviceBridgeProvider.kt
@@ -9,11 +9,7 @@ internal class DeviceBridgeProvider {
     private var instance: DeviceBridge? = null
 
     internal fun get(adbPath: File, adbTimeoutMs: Int, logger: Logger): DeviceBridge =
-        if (instance != null) {
-          instance as DeviceBridge
-        } else {
-          DeviceBridge(adbPath, adbTimeoutMs, logger)
-        }
+        instance ?: RealDeviceBridge(adbPath, adbTimeoutMs, logger)
 
     @VisibleForTesting internal fun setInstance(deviceBridge: DeviceBridge) {
       instance = deviceBridge

--- a/okreplay-gradle-plugin/src/main/kotlin/okreplay/PullTapesTask.kt
+++ b/okreplay-gradle-plugin/src/main/kotlin/okreplay/PullTapesTask.kt
@@ -26,16 +26,18 @@ abstract class PullTapesTask : DefaultTask(), TapeTask {
     FileUtils.forceMkdir(localDir)
 
     val deviceBridge = DeviceBridgeProvider.get(adbPath.get(), adbTimeout.get(), logger)
-    deviceBridge.devices().forEach { device ->
-      val externalStorage = device.externalStorageDir()
-      if (externalStorage.isNullOrBlank()) {
-        throw TaskExecutionException(this,
-            RuntimeException("Failed to retrieve the device external storage dir."))
-      }
-      try {
-        device.pullDirectory(localDir.absolutePath, "$externalStorage/$REMOTE_TAPES_DIR/${packageName.get()}/")
-      } catch (e: RuntimeException) {
-        logger.error("ADB Command failed: ${e.message}")
+    deviceBridge.use {
+      devices().forEach { device ->
+        val externalStorage = device.externalStorageDir()
+        if (externalStorage.isNullOrBlank()) {
+          throw TaskExecutionException(this@PullTapesTask,
+              RuntimeException("Failed to retrieve the device external storage dir."))
+        }
+        try {
+          device.pullDirectory(localDir.absolutePath, "$externalStorage/$REMOTE_TAPES_DIR/${packageName.get()}/")
+        } catch (e: RuntimeException) {
+          logger.error("ADB Command failed: ${e.message}")
+        }
       }
     }
   }

--- a/okreplay-gradle-plugin/src/test/kotlin/okreplay/FakeDeviceBridge.kt
+++ b/okreplay-gradle-plugin/src/test/kotlin/okreplay/FakeDeviceBridge.kt
@@ -1,0 +1,7 @@
+package okreplay
+
+internal class FakeDeviceBridge(private val devices: List<Device>) : DeviceBridge {
+    override fun use(block: DeviceBridge.() -> Unit) = this.block()
+
+    override fun devices(): List<Device> = devices
+}

--- a/okreplay-gradle-plugin/src/test/kotlin/okreplay/OkReplayPluginTest.kt
+++ b/okreplay-gradle-plugin/src/test/kotlin/okreplay/OkReplayPluginTest.kt
@@ -13,12 +13,11 @@ import org.mockito.BDDMockito.given
 import org.mockito.Mockito.*
 
 class OkReplayPluginTest {
-  private val deviceBridge = mock(DeviceBridge::class.java)
   private val device = mock(Device::class.java)
+  private val deviceBridge = FakeDeviceBridge(listOf(device))
 
   @Before fun setUp() {
     DeviceBridgeProvider.setInstance(deviceBridge)
-    `when`(deviceBridge.devices()).thenReturn(listOf(device))
   }
 
   @Test fun appliesPlugin() {


### PR DESCRIPTION
Resolves #102.

I noticed that `connectedAndroidTest` was sometimes hanging on our project, then found issue #102.

This PR calls `terminate()` on `DeviceProvider` by switching to the newer `DeviceProvider#use` API, which isn't present in AGP 3.5.0. I upgraded to AGP 3.6.0, Gradle 5.6.4 (the minimum supported by this version of AGP), and 2.0.1 of the groovy android gradle plugin in order to use this new method -- if it would be better to stay on AGP 3.5.0, it would be pretty easy to write our own version of `use` instead.