### PR TITLE
Update Sample Tests to use Test Context for getting Tape assets

### DIFF
--- a/okreplay-sample/src/androidTest/java/okreplay/sample/ExampleInstrumentedBarTest.java
+++ b/okreplay-sample/src/androidTest/java/okreplay/sample/ExampleInstrumentedBarTest.java
@@ -35,7 +35,7 @@ public class ExampleInstrumentedBarTest {
   private final ActivityTestRule<MainActivity> activityTestRule =
       new ActivityTestRule<>(MainActivity.class);
   private final OkReplayConfig configuration = new OkReplayConfig.Builder()
-      .tapeRoot(new AndroidTapeRoot(ApplicationProvider.getApplicationContext(), getClass()))
+      .tapeRoot(new AndroidTapeRoot(InstrumentationRegistry.getContext(), getClass()))
       .defaultMode(TapeMode.READ_WRITE)
       .sslEnabled(true)
       .interceptor(graph.getOkReplayInterceptor())

--- a/okreplay-sample/src/androidTest/java/okreplay/sample/ExampleInstrumentedFooTest.java
+++ b/okreplay-sample/src/androidTest/java/okreplay/sample/ExampleInstrumentedFooTest.java
@@ -37,7 +37,7 @@ public class ExampleInstrumentedFooTest {
   private final ActivityTestRule<MainActivity> activityTestRule =
       new ActivityTestRule<>(MainActivity.class);
   private final AssetManager assetManager =
-      new AssetManager(ApplicationProvider.getApplicationContext());
+      new AssetManager(InstrumentationRegistry.getContext());
   private final OkReplayConfig configuration = new OkReplayConfig.Builder()
       .tapeRoot(new AndroidTapeRoot(assetManager, getClass().getSimpleName()))
       .defaultMode(TapeMode.READ_WRITE)


### PR DESCRIPTION
ApplicationProvider.getApplicationContext() provides the target application context. But we would need the application context of the Test APK as the assets are bundled in the test app