### PR TITLE
[Fix] bump version vanniktech to 0.11.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,9 +12,7 @@ ext {
   dep = [
       // Build and upload with:
       // ./gradlew clean assemble sourcesJar androidSourcesJar javadocsJar androidJavadocsJar uploadArchives --no-daemon --no-parallel
-      // Need to use snapshot version and explicitly include javadoc/sources tasks until
-      // https://github.com/vanniktech/gradle-maven-publish-plugin/issues/54 is fixed.
-      gradleMavenPublishPlugin : 'com.vanniktech:gradle-maven-publish-plugin:0.9.0-SNAPSHOT',
+      gradleMavenPublishPlugin : 'com.vanniktech:gradle-maven-publish-plugin:0.11.1',
       androidPlugin            : 'com.android.tools.build:gradle:3.6.0',
       groovyPlugin             : 'org.codehaus.groovy:groovy-android-gradle-plugin:2.0.1',
       nexusPlugin              : 'com.bmuschko:gradle-nexus-plugin:2.3.1',

--- a/okreplay-sample/src/androidTest/java/okreplay/sample/ExampleInstrumentedBarTest.java
+++ b/okreplay-sample/src/androidTest/java/okreplay/sample/ExampleInstrumentedBarTest.java
@@ -1,11 +1,5 @@
 package okreplay.sample;
 
-import androidx.test.core.app.ApplicationProvider;
-import androidx.test.espresso.IdlingRegistry;
-import androidx.test.espresso.IdlingResource;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.rule.ActivityTestRule;
-
 import com.jakewharton.espresso.OkHttp3IdlingResource;
 
 import org.junit.After;
@@ -15,6 +9,11 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 
+import androidx.test.espresso.IdlingRegistry;
+import androidx.test.espresso.IdlingResource;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.rule.ActivityTestRule;
 import okreplay.AndroidTapeRoot;
 import okreplay.MatchRules;
 import okreplay.OkReplay;
@@ -31,33 +30,36 @@ import static org.hamcrest.CoreMatchers.containsString;
 
 @RunWith(AndroidJUnit4.class)
 public class ExampleInstrumentedBarTest {
-  private final DependencyGraph graph = DependencyGraph.Companion.instance();
-  private final ActivityTestRule<MainActivity> activityTestRule =
-      new ActivityTestRule<>(MainActivity.class);
-  private final OkReplayConfig configuration = new OkReplayConfig.Builder()
-      .tapeRoot(new AndroidTapeRoot(InstrumentationRegistry.getContext(), getClass()))
-      .defaultMode(TapeMode.READ_WRITE)
-      .sslEnabled(true)
-      .interceptor(graph.getOkReplayInterceptor())
-      .defaultMatchRules(MatchRules.host, MatchRules.path, MatchRules.method)
-      .build();
-  @Rule public final TestRule testRule =
-      new OkReplayRuleChain(configuration, activityTestRule).get();
-  private final IdlingResource okHttp3IdlingResource =
-      OkHttp3IdlingResource.create("OkHttp", graph.getOkHttpClient());
+	private final DependencyGraph graph = DependencyGraph.Companion.instance();
+	private final ActivityTestRule<MainActivity> activityTestRule =
+		new ActivityTestRule<>(MainActivity.class);
+	private final OkReplayConfig configuration = new OkReplayConfig.Builder()
+		.tapeRoot(new AndroidTapeRoot(InstrumentationRegistry.getInstrumentation().getTargetContext(), getClass()))
+		.defaultMode(TapeMode.READ_WRITE)
+		.sslEnabled(true)
+		.interceptor(graph.getOkReplayInterceptor())
+		.defaultMatchRules(MatchRules.host, MatchRules.path, MatchRules.method)
+		.build();
+	@Rule
+	public final TestRule testRule =
+		new OkReplayRuleChain(configuration, activityTestRule).get();
+	private final IdlingResource okHttp3IdlingResource =
+		OkHttp3IdlingResource.create("OkHttp", graph.getOkHttpClient());
 
-  @Before public void setUp() {
-    IdlingRegistry.getInstance().register(okHttp3IdlingResource);
-  }
+	@Before
+	public void setUp() {
+		IdlingRegistry.getInstance().register(okHttp3IdlingResource);
+	}
 
-  @After public void tearDown() {
-    IdlingRegistry.getInstance().register(okHttp3IdlingResource);
-  }
+	@After
+	public void tearDown() {
+		IdlingRegistry.getInstance().register(okHttp3IdlingResource);
+	}
 
-  @Test
-  @OkReplay
-  public void bar() {
-    onView(withId(R.id.navigation_repositories)).perform(click());
-    onView(withId(R.id.message)).check(matches(withText(containsString("AbsListViewHelper"))));
-  }
+	@Test
+	@OkReplay
+	public void bar() {
+		onView(withId(R.id.navigation_repositories)).perform(click());
+		onView(withId(R.id.message)).check(matches(withText(containsString("AbsListViewHelper"))));
+	}
 }

--- a/okreplay-sample/src/androidTest/java/okreplay/sample/ExampleInstrumentedFooTest.java
+++ b/okreplay-sample/src/androidTest/java/okreplay/sample/ExampleInstrumentedFooTest.java
@@ -1,11 +1,5 @@
 package okreplay.sample;
 
-import androidx.test.core.app.ApplicationProvider;
-import androidx.test.espresso.IdlingRegistry;
-import androidx.test.espresso.IdlingResource;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.rule.ActivityTestRule;
-
 import com.jakewharton.espresso.OkHttp3IdlingResource;
 
 import org.junit.After;
@@ -15,6 +9,12 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.IdlingRegistry;
+import androidx.test.espresso.IdlingResource;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.rule.ActivityTestRule;
 import okreplay.AndroidTapeRoot;
 import okreplay.AssetManager;
 import okreplay.MatchRules;
@@ -33,36 +33,39 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(AndroidJUnit4.class)
 public class ExampleInstrumentedFooTest {
-  private final DependencyGraph graph = DependencyGraph.Companion.instance();
-  private final ActivityTestRule<MainActivity> activityTestRule =
-      new ActivityTestRule<>(MainActivity.class);
-  private final AssetManager assetManager =
-      new AssetManager(InstrumentationRegistry.getContext());
-  private final OkReplayConfig configuration = new OkReplayConfig.Builder()
-      .tapeRoot(new AndroidTapeRoot(assetManager, getClass().getSimpleName()))
-      .defaultMode(TapeMode.READ_WRITE)
-      .sslEnabled(true)
-      .interceptor(graph.getOkReplayInterceptor())
-      .defaultMatchRules(MatchRules.host, MatchRules.path, MatchRules.method)
-      .build();
-  @Rule public final TestRule testRule =
-      new OkReplayRuleChain(configuration, activityTestRule).get();
-  private final IdlingResource okHttp3IdlingResource =
-      OkHttp3IdlingResource.create("OkHttp", graph.getOkHttpClient());
+	private final DependencyGraph graph = DependencyGraph.Companion.instance();
+	private final ActivityTestRule<MainActivity> activityTestRule =
+		new ActivityTestRule<>(MainActivity.class);
+	private final AssetManager assetManager =
+		new AssetManager(InstrumentationRegistry.getInstrumentation().getTargetContext());
+	private final OkReplayConfig configuration = new OkReplayConfig.Builder()
+		.tapeRoot(new AndroidTapeRoot(assetManager, getClass().getSimpleName()))
+		.defaultMode(TapeMode.READ_WRITE)
+		.sslEnabled(true)
+		.interceptor(graph.getOkReplayInterceptor())
+		.defaultMatchRules(MatchRules.host, MatchRules.path, MatchRules.method)
+		.build();
+	@Rule
+	public final TestRule testRule =
+		new OkReplayRuleChain(configuration, activityTestRule).get();
+	private final IdlingResource okHttp3IdlingResource =
+		OkHttp3IdlingResource.create("OkHttp", graph.getOkHttpClient());
 
-  @Before public void setUp() {
-    IdlingRegistry.getInstance().register(okHttp3IdlingResource);
-  }
+	@Before
+	public void setUp() {
+		IdlingRegistry.getInstance().register(okHttp3IdlingResource);
+	}
 
-  @After public void tearDown() {
-    IdlingRegistry.getInstance().register(okHttp3IdlingResource);
-  }
+	@After
+	public void tearDown() {
+		IdlingRegistry.getInstance().register(okHttp3IdlingResource);
+	}
 
-  @Test
-  @OkReplay
-  public void foo() {
-    assertEquals("okreplay.sample", ApplicationProvider.getApplicationContext().getPackageName());
-    onView(withId(R.id.navigation_repositories)).perform(click());
-    onView(withId(R.id.message)).check(matches(withText(containsString("6502Android"))));
-  }
+	@Test
+	@OkReplay
+	public void foo() {
+		assertEquals("okreplay.sample", ApplicationProvider.getApplicationContext().getPackageName());
+		onView(withId(R.id.navigation_repositories)).perform(click());
+		onView(withId(R.id.message)).check(matches(withText(containsString("6502Android"))));
+	}
 }


### PR DESCRIPTION
bump up version, to fix artifact issue. Please see below log.

```
A problem occurred configuring project ':okreplay-core'.
> Could not resolve all artifacts for configuration ':okreplay-core:classpath'.
   > Could not find com.vanniktech:gradle-maven-publish-plugin:0.9.0-SNAPSHOT.
     Searched in the following locations:
       - https://jcenter.bintray.com/com/vanniktech/gradle-maven-publish-plugin/0.9.0-SNAPSHOT/maven-metadata.xml
       - https://jcenter.bintray.com/com/vanniktech/gradle-maven-publish-plugin/0.9.0-SNAPSHOT/gradle-maven-publish-plugin-0.9.0-SNAPSHOT.pom
       - https://jcenter.bintray.com/com/vanniktech/gradle-maven-publish-plugin/0.9.0-SNAPSHOT/gradle-maven-publish-plugin-0.9.0-SNAPSHOT.jar
       - file:/Users/aditya.gumay/.m2/repository/com/vanniktech/gradle-maven-publish-plugin/0.9.0-SNAPSHOT/maven-metadata.xml
       - file:/Users/aditya.gumay/.m2/repository/com/vanniktech/gradle-maven-publish-plugin/0.9.0-SNAPSHOT/gradle-maven-publish-plugin-0.9.0-SNAPSHOT.pom
       - file:/Users/aditya.gumay/.m2/repository/com/vanniktech/gradle-maven-publish-plugin/0.9.0-SNAPSHOT/gradle-maven-publish-plugin-0.9.0-SNAPSHOT.jar
       - https://oss.sonatype.org/content/repositories/snapshots/com/vanniktech/gradle-maven-publish-plugin/0.9.0-SNAPSHOT/maven-metadata.xml
       - https://oss.sonatype.org/content/repositories/snapshots/com/vanniktech/gradle-maven-publish-plugin/0.9.0-SNAPSHOT/gradle-maven-publish-plugin-0.9.0-SNAPSHOT.pom
       - https://oss.sonatype.org/content/repositories/snapshots/com/vanniktech/gradle-maven-publish-plugin/0.9.0-SNAPSHOT/gradle-maven-publish-plugin-0.9.0-SNAPSHOT.jar
       - https://maven.google.com/com/vanniktech/gradle-maven-publish-plugin/0.9.0-SNAPSHOT/maven-metadata.xml
       - https://maven.google.com/com/vanniktech/gradle-maven-publish-plugin/0.9.0-SNAPSHOT/gradle-maven-publish-plugin-0.9.0-SNAPSHOT.pom
       - https://maven.google.com/com/vanniktech/gradle-maven-publish-plugin/0.9.0-SNAPSHOT/gradle-maven-publish-plugin-0.9.0-SNAPSHOT.jar
     Required by:
         project :okreplay-core

Possible solution:
 - Declare repository providing the artifact, see the documentation at https://docs.gradle.org/current/userguide/declaring_repositories.html
```