### PR TITLE
Opened OkReplayInterceptor for inheritance

### DIFF
--- a/okreplay-core/src/main/java/okreplay/OkReplayInterceptor.kt
+++ b/okreplay-core/src/main/java/okreplay/OkReplayInterceptor.kt
@@ -10,7 +10,7 @@ import okhttp3.ResponseBody
 
 import okreplay.Util.VIA
 
-class OkReplayInterceptor : Interceptor {
+open class OkReplayInterceptor : Interceptor {
   private var configuration: OkReplayConfig? = null
   private var tape: Tape? = null
   private var isRunning: Boolean = false
@@ -128,13 +128,13 @@ class OkReplayInterceptor : Interceptor {
         .build()
   }
 
-  fun start(configuration: OkReplayConfig, tape: Tape?) {
+  open fun start(configuration: OkReplayConfig, tape: Tape?) {
     this.configuration = configuration
     this.tape = tape
     isRunning = true
   }
 
-  fun stop() {
+  open fun stop() {
     isRunning = false
   }
 


### PR DESCRIPTION
I've made `OkReplayInterceptor` open for inheritance, so that users can modify interceptor behavior for their need, as it was previously in version `1.4.0` with Java code. After migration to Kotlin, this issue appeared, so I suppose it was forgotten to put `open` modifier as in Java classes are not final by design and vice versa in Kotlin. 