### PR TITLE
Fixed some OKReplay issues.

### DIFF
--- a/okreplay-core/src/main/java/okreplay/OkReplayInterceptor.kt
+++ b/okreplay-core/src/main/java/okreplay/OkReplayInterceptor.kt
@@ -69,13 +69,9 @@ class OkReplayInterceptor : Interceptor {
     okhttpResponse = setOkReplayHeader(okhttpResponse, "REC")
     okhttpResponse = setViaHeader(okhttpResponse)
     LOG.info("Recording request ${request.method()} ${request.url()} to tape '${tape.name}'")
-    val bodyClone = OkHttpResponseAdapter.cloneResponseBody(okhttpResponse.body()!!)
+    val bodyClone = OkHttpResponseAdapter.cloneResponseBody(okhttpResponse.peekBody(Long.MAX_VALUE))
     val recordedResponse = OkHttpResponseAdapter.adapt(okhttpResponse, bodyClone)
     tape.record(recordedRequest, recordedResponse)
-    okhttpResponse = okhttpResponse.newBuilder()
-        .body(OkHttpResponseAdapter.cloneResponseBody(okhttpResponse.body()!!))
-        .build()
-    okhttpResponse.body()!!.close()
     return okhttpResponse
   }
 

--- a/okreplay-core/src/main/java/okreplay/RecordedMessage.java
+++ b/okreplay-core/src/main/java/okreplay/RecordedMessage.java
@@ -36,20 +36,4 @@ abstract class RecordedMessage extends AbstractMessage {
     }
     return new LinkedHashMap<>(result);
   }
-
-  Object maybeBodyAsString() {
-    if (body == null) {
-      return null;
-    } else {
-      // Try to determine if the body content type is text
-      String mediaType = MediaType.parse(getContentType()).type();
-      // For text or application media types, assume it's readable text and return the body
-      // as a String
-      if (mediaType.equals("text") || mediaType.equals("application")) {
-        return bodyAsText();
-      } else {
-        return body;
-      }
-    }
-  }
 }

--- a/okreplay-core/src/main/java/okreplay/RecordedRequest.java
+++ b/okreplay-core/src/main/java/okreplay/RecordedRequest.java
@@ -52,7 +52,7 @@ class RecordedRequest extends RecordedMessage implements Request {
   }
 
   @Override public YamlRecordedRequest toYaml() {
-    return new YamlRecordedRequest(headersAsMap(), maybeBodyAsString(), method, url.uri());
+    return new YamlRecordedRequest(headersAsMap(), body, method, url.uri());
   }
 
   static class Builder {

--- a/okreplay-core/src/main/java/okreplay/RecordedResponse.java
+++ b/okreplay-core/src/main/java/okreplay/RecordedResponse.java
@@ -37,7 +37,7 @@ class RecordedResponse extends RecordedMessage implements Response {
   }
 
   @Override public YamlRecordedResponse toYaml() {
-    return new YamlRecordedResponse(headersAsMap(), maybeBodyAsString(), code);
+    return new YamlRecordedResponse(headersAsMap(), body, code);
   }
 
   static class Builder {


### PR DESCRIPTION
# Summary
 The main fixes are the followings:
- Used `peekBody` in `OkReplayInterceptor` to avoid body consumed in advance.
- Used bytes directly as we constructed a wrong string in a compressed response.
# Reviewers
Hi, @rossbacher , could you help review it when you got a free? Thanks!